### PR TITLE
Made SkjermingKlient independent of AzureTokenProvider, parameter is a function

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/Application.kt
@@ -4,17 +4,20 @@ import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.tiltakspenger.skjerming.klient.SkjermingKlient
+import no.nav.tiltakspenger.skjerming.oauth.AzureTokenProvider
 
 private val LOG = KotlinLogging.logger {}
 
 fun main() {
     Thread.setDefaultUncaughtExceptionHandler { _, e -> LOG.error(e) { e.message } }
 
+    val tokenProvider = AzureTokenProvider()
+
     RapidApplication.create(Configuration.rapidsAndRivers).apply {
 
         SkjermingService(
             rapidsConnection = this,
-            skjermingKlient = SkjermingKlient()
+            skjermingKlient = SkjermingKlient(tokenProviderBlock = tokenProvider::getToken)
         )
 
         register(object : RapidsConnection.StatusListener {

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/Application.kt
@@ -17,7 +17,7 @@ fun main() {
 
         SkjermingService(
             rapidsConnection = this,
-            skjermingKlient = SkjermingKlient(tokenProviderBlock = tokenProvider::getToken)
+            skjermingKlient = SkjermingKlient(getToken = tokenProvider::getToken)
         )
 
         register(object : RapidsConnection.StatusListener {

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
@@ -22,7 +22,7 @@ import no.nav.tiltakspenger.skjerming.defaultObjectMapper
 class SkjermingKlient(
     private val skjermingConfig: Configuration.SkjermingKlientConfig = Configuration.SkjermingKlientConfig(),
     private val objectMapper: ObjectMapper = defaultObjectMapper(),
-    private val tokenProviderBlock: suspend () -> String,
+    private val getToken: suspend () -> String,
     engine: HttpClientEngine = CIO.create(),
     private val httpClient: HttpClient = defaultHttpClient(
         objectMapper = objectMapper,
@@ -32,7 +32,7 @@ class SkjermingKlient(
             bearer {
                 loadTokens {
                     BearerTokens(
-                        accessToken = tokenProviderBlock.invoke(),
+                        accessToken = getToken(),
                         // Refresh token are used in refreshToken method if client gets 401
                         // Should't need this if token expiry is checked first
                         refreshToken = emptyRefreshToken,

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
@@ -18,13 +18,11 @@ import io.ktor.http.contentType
 import no.nav.tiltakspenger.skjerming.Configuration
 import no.nav.tiltakspenger.skjerming.defaultHttpClient
 import no.nav.tiltakspenger.skjerming.defaultObjectMapper
-import no.nav.tiltakspenger.skjerming.oauth.AzureTokenProvider
-import no.nav.tiltakspenger.skjerming.oauth.TokenProvider
 
 class SkjermingKlient(
     private val skjermingConfig: Configuration.SkjermingKlientConfig = Configuration.SkjermingKlientConfig(),
     private val objectMapper: ObjectMapper = defaultObjectMapper(),
-    private val provider: TokenProvider = AzureTokenProvider(),
+    private val tokenProviderBlock: () -> String,
     engine: HttpClientEngine = CIO.create(),
     private val httpClient: HttpClient = defaultHttpClient(
         objectMapper = objectMapper,
@@ -34,7 +32,7 @@ class SkjermingKlient(
             bearer {
                 loadTokens {
                     BearerTokens(
-                        accessToken = provider.getToken(),
+                        accessToken = tokenProviderBlock.invoke(),
                         // Refresh token are used in refreshToken method if client gets 401
                         // Should't need this if token expiry is checked first
                         refreshToken = emptyRefreshToken,

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlient.kt
@@ -22,7 +22,7 @@ import no.nav.tiltakspenger.skjerming.defaultObjectMapper
 class SkjermingKlient(
     private val skjermingConfig: Configuration.SkjermingKlientConfig = Configuration.SkjermingKlientConfig(),
     private val objectMapper: ObjectMapper = defaultObjectMapper(),
-    private val tokenProviderBlock: () -> String,
+    private val tokenProviderBlock: suspend () -> String,
     engine: HttpClientEngine = CIO.create(),
     private val httpClient: HttpClient = defaultHttpClient(
         objectMapper = objectMapper,

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/AzureTokenProvider.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/AzureTokenProvider.kt
@@ -9,6 +9,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.http.Parameters
+import kotlinx.coroutines.runBlocking
 import no.nav.tiltakspenger.skjerming.Configuration
 import no.nav.tiltakspenger.skjerming.defaultHttpClient
 import no.nav.tiltakspenger.skjerming.defaultObjectMapper
@@ -24,10 +25,12 @@ class AzureTokenProvider(
 
     private val tokenCache = TokenCache()
 
-    override suspend fun getToken(): String {
-        val currentToken = tokenCache.token
-        if (currentToken != null && !tokenCache.isExpired()) return currentToken
-        return clientCredentials()
+    override fun getToken(): String {
+        return runBlocking {
+            val currentToken = tokenCache.token
+            if (currentToken != null && !tokenCache.isExpired()) currentToken
+            else clientCredentials()
+        }
     }
 
     private suspend fun wellknown(): WellKnown {

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/AzureTokenProvider.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/AzureTokenProvider.kt
@@ -9,7 +9,6 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.http.Parameters
-import kotlinx.coroutines.runBlocking
 import no.nav.tiltakspenger.skjerming.Configuration
 import no.nav.tiltakspenger.skjerming.defaultHttpClient
 import no.nav.tiltakspenger.skjerming.defaultObjectMapper
@@ -25,12 +24,10 @@ class AzureTokenProvider(
 
     private val tokenCache = TokenCache()
 
-    override fun getToken(): String {
-        return runBlocking {
-            val currentToken = tokenCache.token
-            if (currentToken != null && !tokenCache.isExpired()) currentToken
-            else clientCredentials()
-        }
+    override suspend fun getToken(): String {
+        val currentToken = tokenCache.token
+        return if (currentToken != null && !tokenCache.isExpired()) currentToken
+        else clientCredentials()
     }
 
     private suspend fun wellknown(): WellKnown {

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/TokenProvider.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/TokenProvider.kt
@@ -2,5 +2,5 @@ package no.nav.tiltakspenger.skjerming.oauth
 
 fun interface TokenProvider {
 
-    fun getToken(): String
+    suspend fun getToken(): String
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/TokenProvider.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/skjerming/oauth/TokenProvider.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltakspenger.skjerming.oauth
 
-interface TokenProvider {
+fun interface TokenProvider {
 
-    suspend fun getToken(): String
+    fun getToken(): String
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlientTest.kt
@@ -21,11 +21,12 @@ import org.junit.jupiter.api.Test
 @Suppress("TooGenericExceptionThrown")
 internal class SkjermingKlientTest {
 
+    companion object {
+        const val accessToken = "woopwoop"
+    }
+
     @Test
     fun `skal inkludere Azure token i header`() {
-
-        val tokenProvider = mockk<TokenProvider>()
-        coEvery { tokenProvider.getToken() } returns "woopwoop"
 
         var actualAuthHeader: String? = null
         val mockEngine = MockEngine { request ->
@@ -42,7 +43,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            provider = tokenProvider,
+            tokenProviderBlock = { accessToken },
             engine = mockEngine
         )
 
@@ -52,14 +53,11 @@ internal class SkjermingKlientTest {
                 behovId = "y"
             )
         }
-        assertEquals("Bearer woopwoop", actualAuthHeader)
+        assertEquals("Bearer $accessToken", actualAuthHeader)
     }
 
     @Test
     fun `skal klare å deserialisere bodyen som returneres`() {
-
-        val tokenProvider = mockk<TokenProvider>()
-        coEvery { tokenProvider.getToken() } returns "woopwoop"
 
         val mockEngine = MockEngine { request ->
             println("URL er ${request.url}")
@@ -75,7 +73,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            provider = tokenProvider,
+            tokenProviderBlock = { accessToken },
             engine = mockEngine
         )
 
@@ -107,7 +105,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            provider = tokenProvider,
+            tokenProviderBlock = { accessToken },
             engine = mockEngine
         )
 

--- a/src/test/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/skjerming/klient/SkjermingKlientTest.kt
@@ -43,7 +43,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            tokenProviderBlock = { accessToken },
+            getToken = { accessToken },
             engine = mockEngine
         )
 
@@ -73,7 +73,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            tokenProviderBlock = { accessToken },
+            getToken = { accessToken },
             engine = mockEngine
         )
 
@@ -105,7 +105,7 @@ internal class SkjermingKlientTest {
         val client = SkjermingKlient(
             skjermingConfig = Configuration.SkjermingKlientConfig(baseUrl = "http://localhost:8080"),
             objectMapper = defaultObjectMapper(),
-            tokenProviderBlock = { accessToken },
+            getToken = { accessToken },
             engine = mockEngine
         )
 


### PR DESCRIPTION
Jeg er ikke helt sikker på om dette er en kul ting eller ikke, men tenkte at det kanskje var bra hvis man skulle endre så Token-håndteringen er i et bibliotek. Men jeg måtte legge inn en `runBlocking {}` inni der for å få det til. 

Noen tanker?